### PR TITLE
Make establish_connection resilient to AMC.

### DIFF
--- a/lib/octoshark/active_record_extensions.rb
+++ b/lib/octoshark/active_record_extensions.rb
@@ -1,5 +1,34 @@
+module AliasMethodChainResilient
+  # Give us a module which will intercept attempts to alias methods named in
+  # the keys of method_aliases, and instead alias the methods named in the
+  # values of method_aliases.
+  def self.alias_intercepting_module(method_aliases)
+    Module.new do
+      define_method :alias_method do |new_name, old_name|
+        if method_aliases.key?(old_name.to_sym)
+          super new_name, method_aliases[old_name.to_sym]
+        else
+          super new_name, old_name
+        end
+      end
+    end
+  end
+
+  def prepend_features(base)
+    method_aliases = instance_methods.each_with_object({}) do |method_name, aliases|
+      aliases[method_name] = :"__#{method_name}_before_#{self.name}"
+      base.send :alias_method, aliases[method_name], method_name
+    end
+
+    base.singleton_class.send :prepend, AliasMethodChainResilient.alias_intercepting_module(method_aliases)
+    super
+  end
+end
+
 module Octoshark
   module EstablishConnectionWithOctosharkReloading
+    extend AliasMethodChainResilient
+
     def establish_connection(*)
       super
       Octoshark.reload! if Octoshark.configured?

--- a/spec/octoshark/active_record_extensions_spec.rb
+++ b/spec/octoshark/active_record_extensions_spec.rb
@@ -42,4 +42,17 @@ describe "ActiveRecord Extensions" do
 
     ActiveRecord::Base.logger = nil
   end
+
+  it "is resilient to other libraries alias_method_chaining #establish_connection" do
+    class << ActiveRecord::Base
+      def establish_connection_with_monkey_patching(*args)
+        # Noop
+        establish_connection_without_monkey_patching(*args)
+      end
+      alias_method_chain :establish_connection, :monkey_patching
+    end
+
+    spec = ActiveRecord::Base.remove_connection
+    ActiveRecord::Base.establish_connection(spec)
+  end
 end


### PR DESCRIPTION
Clearly, AliasMethodChainResilient doesn't belong here. The question is: is
this a good approach? And if so, should AliasMethodChainResilient live in the
Octoshark gem or in its own gem?
