### PR TITLE
Fix separation of positional and keyword args in Ruby 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   legacy:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     services:
       mysql:
         image: mysql:5.5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,11 +91,15 @@ jobs:
             ruby: 2.6
           - gemfile: rails5.2
             ruby: 2.6
+          - gemfile: rails5.2
+            ruby: 3.0
 
           - gemfile: rails6.0
             ruby: 2.7
           - gemfile: rails6.1
             ruby: 2.7
+          - gemfile: rails6.1
+            ruby: 3.0
 
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,11 @@ jobs:
       matrix:
         include:
           - gemfile: rails3.0
-            ruby: 2.2
+            ruby: 2.4
           - gemfile: rails3.1
-            ruby: 2.2
+            ruby: 2.4
           - gemfile: rails3.2
-            ruby: 2.2
+            ruby: 2.4
 
           - gemfile: rails4.0
             ruby: 2.4

--- a/lib/octoshark/active_record_extensions.rb
+++ b/lib/octoshark/active_record_extensions.rb
@@ -1,8 +1,8 @@
 module Octoshark
   module ConnectionHandler
-    def establish_connection(*args)
+    def establish_connection(*args, **kwargs)
       Octoshark::ConnectionPoolsManager.reset_connection_managers!
-      super(*args)
+      super(*args, **kwargs)
     end
   end
 

--- a/lib/octoshark/active_record_extensions.rb
+++ b/lib/octoshark/active_record_extensions.rb
@@ -1,8 +1,25 @@
 module Octoshark
   module ConnectionHandler
+    # def establish_connection(owner, spec)                        # Rails 3.x
+    # def establish_connection(config_or_env = nil)                # Rails 4.x - 6.1
+    # def establish_connection(config, owner_name:, role:, shard:) # Rails 6.2+
     def establish_connection(*args, **kwargs)
       Octoshark::ConnectionPoolsManager.reset_connection_managers!
-      super(*args, **kwargs)
+
+      if kwargs.empty?
+        # For backward compatibility with older versions of Rails on Ruby 3
+        # that separates positional (args) and keyword arguments (kwargs).
+        super(*args)
+      else
+        super(*args, **kwargs)
+      end
+    end
+  end
+
+  module ConnectionHandlerRails3
+    def establish_connection(*args)
+      Octoshark::ConnectionPoolsManager.reset_connection_managers!
+      super(*args)
     end
   end
 
@@ -19,13 +36,10 @@ module Octoshark
   end
 end
 
-if defined?(ActiveRecord::ConnectionAdapters::ConnectionHandler)
-  # Rails 3.2, 4.0, 4.1, 4.2, 5.0
-  ActiveRecord::ConnectionAdapters::ConnectionHandler.send(:prepend, Octoshark::ConnectionHandler)
-else
-  # Rails 3.0 and 3.1 does not lazy load
+# Rails 3.0 and 3.1 does not lazy load
+unless defined?(ActiveRecord::ConnectionAdapters::ConnectionHandler)
   require 'active_record/connection_adapters/abstract_adapter'
-  ActiveRecord::ConnectionAdapters::ConnectionHandler.send(:prepend, Octoshark::ConnectionHandler)
 end
 
+ActiveRecord::ConnectionAdapters::ConnectionHandler.send(:prepend, Octoshark::ConnectionHandler)
 ActiveRecord::ConnectionAdapters::AbstractAdapter.send(:prepend, Octoshark::ActiveRecordAbstractAdapter)


### PR DESCRIPTION
Reference: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Closes #39