### PR TITLE
Add kwargs argument to the ActiveRecordAbstractAdapter

### DIFF
--- a/lib/octoshark/active_record_extensions.rb
+++ b/lib/octoshark/active_record_extensions.rb
@@ -26,12 +26,12 @@ module Octoshark
   module ActiveRecordAbstractAdapter
     attr_accessor :connection_name, :database_name
 
-    def log(sql, name = "SQL", *other_args, &block)
+    def log(sql, name = "SQL", *other_args, **kwargs, &block)
       if connection_name || database_name
         name = "[Octoshark: #{[connection_name, database_name].compact.join(' ')}] #{name}"
       end
 
-      super(sql, name, *other_args, &block)
+      super(sql, name, *other_args, **kwargs, &block)
     end
   end
 end


### PR DESCRIPTION
With a Rails 7 upgrade there was an argument error being raised. This fixes the error by properly dispersing the arguments. ex: `{ async: false }` was coming through other_args which is no longer allowed in newer versions of Ruby.


### Before
`rails db:migrate`
![CleanShot 2024-02-22 at 11 30 01@2x](https://github.com/dalibor/octoshark/assets/6271986/046dcf17-9eb5-44f8-9707-8f06cbece8bd)

### After
🎉